### PR TITLE
Fix SUHA 32 cargo_age_period

### DIFF
--- a/src/pax/paxmail_suha32.pnml
+++ b/src/pax/paxmail_suha32.pnml
@@ -373,7 +373,7 @@ item (FEAT_TRAINS, pax_suha_32, 1539) {
 		power: 0;
 		dual_headed: 0;
 		cargo_capacity: 80; 
-//		cargo_age_period: 0;
+		cargo_age_period: 400;
 		refit_cost: 0;
 		default_cargo_type: PASS;
 //		loading_speed: 40;


### PR DESCRIPTION
I had an "express" train with C57 and SUHA 32 wagons, and no matter what I did it was bleeding money.
I noticed in the code that this wagon has cargo aging set to 0, as soon as I switched the SUHA 32 wagons to e.g. OHA 32, my train started being profitable.
So this PR sets SUHA 32 cargo_age_period to 400, no idea if that's the "correct" value, but it's the same as OHA 32 and SUHA 43.
EDIT: maybe the aging period should be even higher? Since SUHA 32 is described as express/night wagon
